### PR TITLE
Fix linking issue, use Python on Windows only and Re-render

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,13 @@
 language: objective-c
 
 env:
-  matrix:
-    
-    - CONDA_PY=27
-    - CONDA_PY=34
-    - CONDA_PY=35
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "ZP3oX68tfKi2PyQXTVIGcm9CUL0W7yWpThGACBRth5R5qE7sJV5gqgUwb0oL9JtwPfpRuFWmd06NqwJPYzIe714/I2RHW3JSqe0XOHN5snRzGdznq6L/VcaaiWvA6z9eumJRajTA608Lz2dRJx5S0iext1UINyfpFbkAnkzcg2A679+09CJHPM0mP7M6gKaj80cIA0et2Y+LCtUMcU1x6ezOi4D2FA2d+o3kCHgMG7b2yUt2Vkny9ifoku7bgdc3IhzXeGgWsHi+9OQFCtEIkBcWWPnvL3uXsMBTkr762lNhnu4grsSkUtivWVgX7aMj5ijlsO6/EcEXkobdZnS9tjZLBs5XowClpnqNcEAANlFZg0rgGYdQg7T9+ZasQFUKjZb1mVQh2fpyUvSGm43VSIJ+0cyhmojDHtkw+BmdbRwQWilKzglFenrDP7x6F9M5q+Sse0eZmW2A3+xQEvKpa8niFoHbgWxCZmpGaM0k335SWESHgixvEUK3o/QoWtTraZBJb6c8czu5jXb5gbMs3YU1VazUYS/u1r6knScW0EyR3CmeouqgbtuJX/8MjfXggUMfpbPFnJ3qlTgIihMmWDjEiwt1eDUC7RjBCbFgqgya80q79z3zWxwPC9AQmuOlIHgT1v392HFi3zXWtJan25W1UURn9ZzdiV5EpcD+fAU="
 
+
+before install:
+    - brew remove --force $(brew list)
 
 install:
     - |

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -43,22 +43,7 @@ conda update --yes --all
 conda install --yes conda-build==1.18.2
 conda info
 
-# Embarking on 3 case(s).
-    set -x
-    export CONDA_PY=27
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    /feedstock_root/ci_support/upload_or_check_non_existence.py /recipe_root conda-forge --channel=main || exit 1
-
-    set -x
-    export CONDA_PY=34
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    /feedstock_root/ci_support/upload_or_check_non_existence.py /recipe_root conda-forge --channel=main || exit 1
-
-    set -x
-    export CONDA_PY=35
-    set +x
+# Embarking on 1 case(s).
     conda build /recipe_root --quiet || exit 1
     /feedstock_root/ci_support/upload_or_check_non_existence.py /recipe_root conda-forge --channel=main || exit 1
 EOF

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,6 +4,7 @@ cd source
 chmod +x configure install-sh
 
 ./configure --prefix="$PREFIX" \
+    --enable-rpath \
     --disable-samples \
     --disable-extras \
     --disable-layout \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,13 +46,13 @@ test:
     {% endfor %}
 
     # CLI tests
-    - genbrk --help              # [unix]
-    - gencfu --help              # [unix]
-    - gencnval --help            # [unix]
-    - gendict --help             # [unix]
-    - icuinfo --help             # [unix]
-    - icu-config --help          # [unix]
-    - makeconv gb-18030-2000.ucm # [unix]
+    - genbrk --help               # [unix]
+    - gencfu --help               # [unix]
+    - gencnval --help             # [unix]
+    - gendict --help              # [unix]
+    - icuinfo --help              # [unix]
+    - icu-config --help           # [unix]
+    - makeconv gb-18030-2000.ucm  # [unix]
 
     # TODO: Windows tests
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,7 @@ source:
     - icu-config.patch                                 # [win]
 
 build:
+  number: 1
   features:
     - vc9     # [win and py27]
     - vc10    # [win and py34]
@@ -23,7 +24,7 @@ build:
 
 requirements:
   build:
-    - python
+    - python  # [win]
 
 test:
   files:


### PR DESCRIPTION
Previously, the `libicudata.*.*.dylib` library on Mac would keep a relative path to itself. In particular, it had a path to `../lib/libicudata.*.*.dylib`, which was a bit strange and caused linking errors for any binary or library that linked against it. As it was a relative path, `conda-build` didn't pick up on the fact that this should be changed to use `@rpath` as it would normally. Here we add the flag `--enable-rpath`, which seems to force `libicudata.*.*.dylib` to embed the full path to itself. This should correct that problem and end the linking issues that every other package has experienced with this library on Mac.

Noticed that Python was being installed as a build dependency on all platforms when this is only needed for Windows. Have now corrected so this is a Windows only dependency.

Also, re-rendered with `conda-smithy` 0.8.3. This will remove brew in case it affected anything. Also, it removes extraneous Python builds from the CircleCI and Travis CI builds.