### PR TITLE
Only enable rpath support on Mac

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,13 +3,19 @@
 cd source
 chmod +x configure install-sh
 
+EXTRA_OPTS=""
+if [ "$(uname)" == "Darwin" ];
+then
+    EXTRA_OPTS="--enable-rpath"
+fi
+
 ./configure --prefix="$PREFIX" \
-    --enable-rpath \
-    --disable-samples \
-    --disable-extras \
-    --disable-layout \
-    --disable-tests \
-    --enable-static
+            --disable-samples \
+            --disable-extras \
+            --disable-layout \
+            --disable-tests \
+            --enable-static \
+	    "${EXTRA_OPTS}"
 
 make -j$CPU_COUNT
 make check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - icu-config.patch                                 # [win]
 
 build:
-  number: 1
+  number: 2
   features:
     - vc9     # [win and py27]
     - vc10    # [win and py34]


### PR DESCRIPTION
Same fix as was proposed in this PR (  https://github.com/conda-forge/icu-feedstock/pull/3 ), but restricted to Mac only. While that fix worked great for Mac, it appears to causing linking problems on Linux. This restricts the fix to Mac only.

Related: https://github.com/conda-forge/icu-feedstock/pull/3
Related: https://github.com/conda-forge/libxml2-feedstock/pull/1
Related: https://circleci.com/gh/conda-forge/libxml2-feedstock/6
Related: https://circleci.com/gh/conda-forge/libxml2-feedstock/7