### PR TITLE
Remove symlinks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
 
       conda config --set show_channel_urls true
       conda update --yes conda
-      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
+      conda install --yes conda-build jinja2 anaconda-client
       conda config --add channels conda-forge
       
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - icu-config.patch                                 # [win]
 
 build:
-  number: 3
+  number: 4
   features:
     - vc9     # [win and py27]
     - vc10    # [win and py34]


### PR DESCRIPTION
Fixes https://github.com/conda-forge/icu-feedstock/issues/9

Seems we forgot to unpin `conda-build` when using the `toolchain`. So we have some symlinks to `conda` stuff floating around. This removes them. The problem here is the same as the one we saw with `hdf5`.

cc @lentils @gillins @msarahan

xref: https://github.com/conda-forge/icu-feedstock/pull/8
xref: https://github.com/conda-forge/hdf5-feedstock/issues/23